### PR TITLE
Avoid wrong links when new topic is related to containers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chokepoint",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "chokepoint",
   "devDependencies": {
     "eslint": "",

--- a/public/chokePoint.html
+++ b/public/chokePoint.html
@@ -216,9 +216,9 @@
         [^[if typeSelected]]
           [^[if typeSelected == 'How to' || typeSelected == 'Technical issue']]
             [^[include tmpl="#platform"/]]
-            [^[if platformSelected]]
+            [^[if platformSelected && platformSelected != 'Containers']]
               [^[include tmpl="#application"/]]
-              [^[if applicationSelected && platformSelected != 'Containers']]
+              [^[if applicationSelected]]
                 [[for applicationValues]]
                   [^[if ~root.applicationSelected == application]]
                     [^[include tmpl="#topic"/]]
@@ -245,14 +245,10 @@
         [^[else typeSelected == 'Suggestion']]
           <button class="button" onclick="cancel()">Cancel</button>
           <button class="button button-accent" onclick="create()">Create topic</button>
-        [^[else applicationSelected && platformSelected == 'Containers']]
-          [[for applicationValues]]
-            [^[if ~root.applicationSelected == application]]
-              <p>The Bitnami Community for container issues is located on GitHub. You can create a GitHub issue clicking on the button.</p>
-              <button class="button" onclick="cancel()">Cancel</button>
-              <button class="button button-accent" onclick="window.open('https://github.com/bitnami/bitnami-docker-[[:~root.applicationSelected]]/issues/new','_blank')">Create GitHub issue</button>
-            [[/if]]
-          [[/for]]
+        [^[else platformSelected == 'Containers']]
+          <p>The Bitnami Community for container issues is located on GitHub. You can create a GitHub issue on the Issues section of the container.</p>
+          <button class="button" onclick="cancel()">Cancel</button>
+          <button class="button button-accent" onclick="window.open('https://github.com/bitnami/','_blank')">Go to Bitnami GitHub</button>
         [[else]]
             <button class="button" onclick="cancel()">Cancel</button>
         [[/if]]


### PR DESCRIPTION
Now, it will create a link to Bitnami GitHub page directly, avoiding wrong links like https://github.com/bitnami/bitnami-docker-LAMP/MAMP/WAMP/issues/new. 

Also, we don't need to know the app at this point since issues are open inside each container project