### PR TITLE
Update chokepoint to get and show the Bndiagnostic information

### DIFF
--- a/assets/javascripts/discourse/initializers/chokePoint.js.es6
+++ b/assets/javascripts/discourse/initializers/chokePoint.js.es6
@@ -8,6 +8,12 @@ export default {
     let showChokePoint = false;
     const applicationArray = [];
     const communityURL = window.location.origin;
+    let endpointURL;
+    if (/community.bitnami.com/.test(window.location.host)) {
+      endpointURL="http://internal-bndiagnostic-retrieval-1263868043.us-east-1.elb.amazonaws.com"
+    } else {
+      endpointURL="http://internal-bndiagnostic-retrieval-dev-1996126494.us-east-1.elb.amazonaws.com"
+    }
     const dropdownData = {
       typeArray: [
         {
@@ -108,7 +114,7 @@ export default {
       ],
       bndiagnosticReasonsArray: [
         {
-          bndiagnosticReason: 'The documentation didn\'t make any significant change',
+          bndiagnosticReason: 'The documentation did not make any significant change',
         },
         {
           bndiagnosticReason: 'I do not know how to perform the changes explained in the documentation',
@@ -216,12 +222,6 @@ export default {
         window.getBndiagnostic = function getBndiagnostic(bnsupport) {
           $('.bndiagnostic__results').empty();
           $('.bndiagnostic__results').append(`<pre class="bndiagnostic__text">Loading results...</pre>`);
-          let endpointURL;
-          if (/community.bitnami.com/.test(window.location.host)) {
-            endpointURL="http://internal-bndiagnostic-retrieval-1263868043.us-east-1.elb.amazonaws.com"
-          } else {
-            endpointURL="http://internal-bndiagnostic-retrieval-dev-1996126494.us-east-1.elb.amazonaws.com"
-          }
 
           $.get(`${endpointURL}?bnsupportID=${bnsupport}`)
             .done(function(value) {
@@ -464,7 +464,7 @@ export default {
 
         /**
         * Action after explaining why the bndiagnostic info was not useful.
-        * Show different textarea asking for information before creating the case
+        * Show a different textarea asking for information before creating the case
         */
         window.goToPage5 = function goToPage5() {
           allData.currentPage = 5;

--- a/assets/javascripts/discourse/initializers/chokePoint.js.es6
+++ b/assets/javascripts/discourse/initializers/chokePoint.js.es6
@@ -240,7 +240,7 @@ export default {
             .fail(function() {
               const bnsupportURL="https://docs.bitnami.com/general/how-to/understand-bnsupport/#run-the-bitnami-support-tool"
               $('.bndiagnostic__results').empty();
-              $('.bndiagnostic__results').append(`<pre class="bndiagnostic__text">Couldn't obtain data or data is outdated. Please update the Bitnami Support Tool to the latest version and run it again
+              $('.bndiagnostic__results').append(`<pre class="bndiagnostic__text">Couldn't obtain data or data is outdated (older than 2 hours). Please update the Bitnami Support Tool to the latest version and run it again
 
 <a href="${bnsupportURL}" target="_blank">${bnsupportURL}</a>
 

--- a/assets/javascripts/discourse/initializers/chokePoint.js.es6
+++ b/assets/javascripts/discourse/initializers/chokePoint.js.es6
@@ -214,6 +214,8 @@ export default {
         * Get the bndiagnostic information
         */
         window.getBndiagnostic = function getBndiagnostic(bnsupport) {
+          $('.bndiagnostic__results').empty();
+          $('.bndiagnostic__results').append(`<pre class="bndiagnostic__text">Loading results...</pre>`);
           let endpointURL;
           if (/community.bitnami.com/.test(window.location.host)) {
             endpointURL="http://internal-bndiagnostic-retrieval-1263868043.us-east-1.elb.amazonaws.com"

--- a/assets/javascripts/discourse/initializers/chokePoint.js.es6
+++ b/assets/javascripts/discourse/initializers/chokePoint.js.es6
@@ -214,13 +214,20 @@ export default {
         * Get the bndiagnostic information
         */
         window.getBndiagnostic = function getBndiagnostic(bnsupport) {
-          $.get(`https://76v23gpdc8.execute-api.us-east-1.amazonaws.com/jotaTestT40193/helloworld?bnsupportID=${bnsupport}`)
+          let endpointURL;
+          if (/community.bitnami.com/.test(window.location.host)) {
+            endpointURL="http://internal-bndiagnostic-retrieval-1263868043.us-east-1.elb.amazonaws.com"
+          } else {
+            endpointURL="http://internal-bndiagnostic-retrieval-dev-1996126494.us-east-1.elb.amazonaws.com"
+          }
+
+          $.get(`${endpointURL}?bnsupportID=${bnsupport}`)
             .done(function(value) {
               allData.bndiagnosticOutput = value;
               $('.button-accent').removeAttr('disabled');
               $('.bndiagnostic__results').empty();
               const arr = value.split("\n");
-              for (var i = 0; i < arr.length; i++) {
+              for (let i = 0; i < arr.length; i++) {
                 if (/\s*http.*/.test(arr[i])) {
                   $('.bndiagnostic__results').append(`<a class="bndiagnostic__text" target="_blank" href="${arr[i]}">${arr[i]}</a>`);
                 } else {

--- a/assets/javascripts/discourse/initializers/chokePoint.js.es6
+++ b/assets/javascripts/discourse/initializers/chokePoint.js.es6
@@ -243,6 +243,8 @@ export default {
               $('.bndiagnostic__results').append(`<pre class="bndiagnostic__text">Couldn't obtain data or data is outdated. Please update the Bitnami Support Tool to the latest version and run it again
 
 <a href="${bnsupportURL}" target="_blank">${bnsupportURL}</a>
+
+If you continue running into issues when running the Bitnami Support tool, please create a new support request using "Bitnami Support Tool" option when clicking on "+ New Topic".
 </pre>`);
             })
         }

--- a/assets/javascripts/discourse/initializers/chokePoint.js.es6
+++ b/assets/javascripts/discourse/initializers/chokePoint.js.es6
@@ -4,7 +4,7 @@ const SearchResultsDefaultController = require('discourse/controllers/full-page-
 export default {
   name: 'chokepoint',
   initialize: function() {
-    const version = 'v1.0.9';
+    const version = 'v1.1.0';
     let showChokePoint = false;
     const applicationArray = [];
     const communityURL = window.location.origin;
@@ -18,9 +18,6 @@ export default {
         },
         {
           type: 'Suggestion',
-        },
-        {
-          type: 'Sales & Account',
         },
       ],
       platformArray: [
@@ -39,18 +36,6 @@ export default {
               subplatform: 'Microsoft Azure',
               query: 'Azure',
             },
-            {
-              subplatform: 'Oracle Cloud Platform',
-              query: 'Oracle',
-            },
-            {
-              subplatform: 'CenturyLink',
-              query: 'CenturyLink',
-            },
-            {
-              subplatform: '1and1',
-              query: '1and1',
-            },
           ],
         },
         {
@@ -64,6 +49,9 @@ export default {
             },
             {
               subplatform: 'OS X',
+            },
+            {
+              subplatform: 'OS X VM',
             },
             {
               subplatform: 'Linux',
@@ -105,6 +93,17 @@ export default {
         {
           topic: 'Upgrade',
           query: 'upgrade OR update OR migrate',
+        },
+      ],
+      bndiagnosticReasonsArray: [
+        {
+          bndiagnosticReason: 'Reason 1',
+        },
+        {
+          bndiagnosticReason: 'Reason 2',
+        },
+        {
+          bndiagnosticReason: 'Other',
         },
       ],
     };
@@ -198,6 +197,24 @@ export default {
         $.views.settings.delimiters('[[', ']]', '^');
 
         /**
+        * Get the bndiagnostic information
+        */
+        window.getBndiagnostic = function getBndiagnostic(bnsupport) {
+          $.get(`https://76v23gpdc8.execute-api.us-east-1.amazonaws.com/jotaTestT40193/helloworld?bnsupportID=${bnsupport}`)
+            .done(function(value) {
+              return value
+            })
+            .fail(function() {
+              return "Couldn't obtain data!"
+            })
+          return `    ✓ Apache: No issues found
+              ✓ Mariadb: No issues found
+              ✓ Connectivity: No issues found
+              ✓ Wordpress: No issues found
+              ? Resources: Found possible issues`
+        }
+
+        /**
         * Adapt the search string
         */
         window.adaptSearch = function adaptSearch(platform, app, topic) {
@@ -261,11 +278,15 @@ export default {
           titleFilled: null,
           bnsupportFilled: null,
           bnsupportAlertShown: false,
+          bndiagnosticReasonsValues: dropdownData.bndiagnosticReasonsArray,
+          bndiagnosticReasonSelected: null,
+          bndiagnosticReasonFilled: null,
           textareaFilled: null,
           textareaSanitized: null,
           currentPage: 1,
           createTopic: 1,
           adaptSearch: adaptSearch,
+          getBndiagnostic: getBndiagnostic,
         };
 
         /**
@@ -368,26 +389,65 @@ export default {
         };
 
         /**
-        * Action after click on "NO" button.
-        * Show different textarea asking for information before creating the case
+        * Action after clicking Next in case of Technical issue
+        * Ask user for the bnsupport tool code
         */
         window.goToPage3 = function goToPage3() {
           allData.currentPage = 3;
-          const page3 = $.templates('#explanationCase');
+          const page3 = $.templates('#bnsupportPage');
           page3.link('#bitnamiContainer', allData);
         };
 
         /**
-        * Action after clicking Next in case of Technical issue
-        * Ask user for the bnsupport tool code
+        * Action after providing the bnsupport information
+        * Wait until we have the bndiagnostic info
+        */
+        window.goToPageWait = function goToPageWait() {
+          allData.currentPage = 40;
+          const page40 = $.templates('#waitPage');
+          page40.link('#bitnamiContainer', allData);
+          goToPage4();
+        };
+
+        /**
+        * Action after providing the bnsupport tool code
+        * Show the user the errors the tool found
         */
         window.goToPage4 = function goToPage4() {
-          if (allData.textareaFilled) {
-            allData.textareaSanitized = escapeHtml(allData.textareaFilled);
-          }
           allData.currentPage = 4;
-          const page4 = $.templates('#bnsupportPage');
+          const page4 = $.templates('#bndiagnosticPage');
           page4.link('#bitnamiContainer', allData);
+        };
+
+        /**
+        * Action after showing the bndiagnostic info
+        * and user says he didn't review it
+        * Tell the user to review it before creating the ticket
+        */
+        window.goToPage41 = function goToPage41() {
+          allData.currentPage = 41;
+          const page41 = $.templates('#bndiagnosticRequired');
+          page41.link('#bitnamiContainer', allData);
+        };
+
+        /**
+        * Bndiagnostic info was not useful
+        * Ask him for more information
+        */
+        window.goToPage5 = function goToPage5() {
+          allData.currentPage = 5;
+          const page5 = $.templates('#bndiagnosticFeedback');
+          page5.link('#bitnamiContainer', allData);
+        };
+
+        /**
+        * Action after explaining why the bndiagnostic info was not useful.
+        * Show different textarea asking for information before creating the case
+        */
+        window.goToPage6 = function goToPage6() {
+          allData.currentPage = 6;
+          const page6 = $.templates('#explanationCase');
+          page6.link('#bitnamiContainer', allData);
         };
 
         /**

--- a/assets/javascripts/discourse/initializers/chokePoint.js.es6
+++ b/assets/javascripts/discourse/initializers/chokePoint.js.es6
@@ -10,9 +10,9 @@ export default {
     const communityURL = window.location.origin;
     let endpointURL;
     if (/community.bitnami.com/.test(window.location.host)) {
-      endpointURL="http://internal-bndiagnostic-retrieval-1263868043.us-east-1.elb.amazonaws.com"
+      endpointURL="https://bndiagnostic-retrieval.web.bitnami.net"
     } else {
-      endpointURL="http://internal-bndiagnostic-retrieval-dev-1996126494.us-east-1.elb.amazonaws.com"
+      endpointURL="https://bndiagnostic-retrieval.dev.bitnami.net"
     }
     const dropdownData = {
       typeArray: [

--- a/assets/javascripts/discourse/initializers/chokePoint.js.es6
+++ b/assets/javascripts/discourse/initializers/chokePoint.js.es6
@@ -114,6 +114,9 @@ export default {
       ],
       bndiagnosticReasonsArray: [
         {
+          bndiagnosticReason: 'The tool could not find any issue',
+        },
+        {
           bndiagnosticReason: 'The documentation did not make any significant change',
         },
         {
@@ -488,8 +491,7 @@ If you continue running into issues when running the Bitnami Support tool, pleas
           if (allData.typeSelected === 'Technical issue') {
             body = `**Keywords:** ${allData.applicationSelected} - ${allData.platformSelected} - ${allData.typeSelected} - ${allData.topicSelected}\n\n`;
             if (allData.bnsupportFilled) body += `**bnsupport ID:** ${allData.bnsupportFilled}\n\n`;
-            if (allData.bndiagnosticOutput) body += `**bndiagnostic output:**\n\`\`\`
-            ${allData.bndiagnosticOutput}\n\`\`\`\n`;
+            if (allData.bndiagnosticOutput) body += `**bndiagnostic output:**\n\`\`\`${allData.bndiagnosticOutput}\`\`\`\n`;
             if (allData.bndiagnosticReasonFilled) {
               body += `**bndiagnostic failure reason:** ${allData.bndiagnosticReasonFilled}\n\n`;
             } else if (allData.bndiagnosticReasonSelected) {

--- a/plugin.rb
+++ b/plugin.rb
@@ -7,5 +7,5 @@ register_asset "javascripts/discourse/initializers/search.js.es6"
 register_asset "javascripts/discourse/initializers/chokePoint.js.es6"
 
 extend_content_security_policy(
-  script_src: ['http://internal-bndiagnostic-retrieval-1263868043.us-east-1.elb.amazonaws.com', 'http://internal-bndiagnostic-retrieval-dev-1996126494.us-east-1.elb.amazonaws.com'],
+  script_src: ['https://bndiagnostic-retrieval.web.bitnami.net', 'https://bndiagnostic-retrieval.dev.bitnami.net'],
 )

--- a/plugin.rb
+++ b/plugin.rb
@@ -7,5 +7,5 @@ register_asset "javascripts/discourse/initializers/search.js.es6"
 register_asset "javascripts/discourse/initializers/chokePoint.js.es6"
 
 extend_content_security_policy(
-  script_src: ['https://76v23gpdc8.execute-api.us-east-1.amazonaws.com'],
+  script_src: ['http://internal-bndiagnostic-retrieval-1263868043.us-east-1.elb.amazonaws.com', 'http://internal-bndiagnostic-retrieval-dev-1996126494.us-east-1.elb.amazonaws.com'],
 )

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,6 +1,6 @@
 # name: bitnami-chokepoint
 # about: Bitnami Discourse topic creation entrypoint
-# version: 1.0.9
+# version: 1.1.0
 # authors: crhernandez, jsalmeron
 
 register_asset "javascripts/discourse/initializers/search.js.es6"

--- a/plugin.rb
+++ b/plugin.rb
@@ -5,3 +5,7 @@
 
 register_asset "javascripts/discourse/initializers/search.js.es6"
 register_asset "javascripts/discourse/initializers/chokePoint.js.es6"
+
+extend_content_security_policy(
+  script_src: ['https://76v23gpdc8.execute-api.us-east-1.amazonaws.com'],
+)

--- a/public/chokePoint.css
+++ b/public/chokePoint.css
@@ -19,11 +19,15 @@
     margin: auto !important;
 }
 
-textarea.bndiagnostic {
+textarea.bndiagnostic__feedback {
     height: 20em !important;
 }
 
 .bitnami-b textarea, p.bnsupport, p.bndiagnostic {
+    max-width: 40em !important;
+}
+
+.bndiagnostic__text {
     max-width: 40em !important;
 }
 
@@ -41,7 +45,7 @@ textarea.bndiagnostic {
 
 .bnsupport {
     min-height: unset !important;
-    max-height: 2.5em !important;
+    max-height: 3em !important;
     max-width: 40em !important;
     resize: none !important;
 }
@@ -55,9 +59,9 @@ textarea.bndiagnostic {
 
 .title {
   min-height: unset !important;
-  max-height: 5em !important;
+  height: 3em !important;
+  max-height: 10em !important;
   max-width: 40em !important;
-  resize: none !important;
 }
 
 .issue {

--- a/public/chokePoint.css
+++ b/public/chokePoint.css
@@ -26,6 +26,7 @@
 .bndiagnostic__text {
     max-width: 49em !important;
     white-space: pre-wrap;
+    display: table;
 }
 
 .tag-small {

--- a/public/chokePoint.css
+++ b/public/chokePoint.css
@@ -24,7 +24,7 @@
 }
 
 .bndiagnostic__text {
-    max-width: 600px !important;
+    max-width: 49em !important;
     white-space: pre-wrap;
 }
 

--- a/public/chokePoint.css
+++ b/public/chokePoint.css
@@ -19,7 +19,11 @@
     margin: auto !important;
 }
 
-.bitnami-b textarea, p.bnsupport {
+textarea.bndiagnostic {
+    height: 20em !important;
+}
+
+.bitnami-b textarea, p.bnsupport, p.bndiagnostic {
     max-width: 40em !important;
 }
 
@@ -38,6 +42,13 @@
 .bnsupport {
     min-height: unset !important;
     max-height: 2.5em !important;
+    max-width: 40em !important;
+    resize: none !important;
+}
+
+.bndiagnostic {
+    min-height: unset !important;
+    max-height: 40em !important;
     max-width: 40em !important;
     resize: none !important;
 }

--- a/public/chokePoint.css
+++ b/public/chokePoint.css
@@ -19,16 +19,13 @@
     margin: auto !important;
 }
 
-textarea.bndiagnostic__feedback {
-    height: 20em !important;
-}
-
-.bitnami-b textarea, p.bnsupport, p.bndiagnostic {
+.bitnami-b textarea, p.bnsupport, .bndiagnostic, .bndiagnostic__results {
     max-width: 40em !important;
 }
 
 .bndiagnostic__text {
-    max-width: 40em !important;
+    max-width: 600px !important;
+    white-space: pre-wrap;
 }
 
 .tag-small {

--- a/public/chokePoint.css
+++ b/public/chokePoint.css
@@ -41,7 +41,7 @@
     margin-top: unset !important;
 }
 
-.bnsupport {
+textarea.bnsupport {
     min-height: unset !important;
     max-height: 3em !important;
     max-width: 40em !important;

--- a/public/chokePoint.html
+++ b/public/chokePoint.html
@@ -127,9 +127,9 @@
 <script id="bnsupport" type="text/x-jsrender">
   <div>
     <h4>Bitnami Support Tool ID <small>required</small></h4>
-    <p class="bnsupport">The Bitnami Support Tool is a command line tool that collects logs and other relevant information and sends it to the Bitnami Support Team. It does not collect any credentials or passwords from your system. </p>
-    <br/>
-    <p class="bnsupport">To ensure we can quickly provide you with a resolution to your question, please run this tool in the affected environment. After running the tool, enter the resulting code in the box below. You can find more information <a href="https://docs.bitnami.com/general/components/bnsupport/" target="_blank">here</a>.</p>
+    <p class="bnsupport" style="color:red;">Running the Bitnami Support Tool is mandatory when creating a ticket in this forum from June 29th. This way we can quickly provide you with a resolution to your question.</p>
+    <p class="bnsupport">The Bitnami Support Tool is a command line tool that collects logs and other relevant information and sends it to the Bitnami Support Team. It does not collect any credentials or passwords from your system. Please run this tool in the affected environment and enter the resulting code in the box below. You can find more information <a href="https://docs.bitnami.com/general/components/bnsupport/" target="_blank">here</a></p>
+    <p class="bnsupport">If you run into any issues when running the Bitnami Support tool, please create a new support request using the "Bitnami Support Tool" option when clicking on "+ New Topic".</p>
     <textarea class="bnsupport" placeholder="12345678-abcd-1234-abcd-123456789abc" maxlength="36" data-link="bnsupportFilled"></textarea>
   </div>
 </script>
@@ -223,7 +223,7 @@
       [^[include tmpl="#bndiagnostic"/]]
       <div class="margin-t-small">
       <button class="button" onclick="cancel()">Cancel</button>
-        <button class="button button-accent" onclick="goToPage5()" disabled="true">Next</button>
+        <button class="button button-accent" onclick="goToPage5()" disabled="true">Yes, but it was not useful</button>
         <div class="text-r padding-r-giant padding-t-normal" style="float: right">
           <a onclick="goToPage3()">Go back</a>
         </div>

--- a/public/chokePoint.html
+++ b/public/chokePoint.html
@@ -113,7 +113,6 @@
     <p class="bndiagnostic">The Bitnami Diagnostic Tool is a self-service command line tool that evaluates your configuration files and logs for errors and provides you with useful information to fix them.</p>
     <p class="bndiagnostic">Did you review this information?</p>
     <div class="bndiagnostic__results">
-      <pre class="bndiagnostic__text">Loading results...</pre>
     </div>
   </div>
 </script>
@@ -284,8 +283,6 @@
                 [[/if]]
               [[/if]]
             [[/if]]
-          [[else typeSelected == 'Sales & Account']]
-            <p>For sales and account questions, we will help you in our HelpDesk service.</p>
           [[else typeSelected == 'Suggestion' || typeSelected == 'Bitnami Support Tool']]
             [^[include tmpl="#title"/]]
             [^[include tmpl="#issue"/]]
@@ -294,9 +291,6 @@
         [^[if ((typeSelected == 'How to' || typeSelected == 'Technical issue') && (platformSelected && !(platformSelected == 'Containers' || platformSelected == 'Charts')) && applicationSelected && topicSelected)]]
           <button class="button" onclick="cancel()">Cancel</button>
           <button class="button button-accent" onclick="goToPage2()">Next</button>
-        [^[else typeSelected == 'Sales & Account']]
-          <button class="button" onclick="cancel()">Cancel</button>
-          <button class="button button-accent" onclick="goToHelpdesk()">Go to Bitnami HelpDesk</button>
         [^[else typeSelected == 'Suggestion' || typeSelected == 'Bitnami Support Tool']]
           <button class="button" onclick="cancel()">Cancel</button>
           <button class="button button-accent" onclick="create()">Create topic</button>

--- a/public/chokePoint.html
+++ b/public/chokePoint.html
@@ -127,7 +127,7 @@
 <script id="bnsupport" type="text/x-jsrender">
   <div>
     <h4>Bitnami Support Tool ID <small>required</small></h4>
-    <p class="bnsupport" style="color:red;">Running the Bitnami Support Tool is mandatory when creating a ticket in this forum from June 29th. This way we can quickly provide you with a resolution to your question.</p>
+    <p class="bnsupport" style="color:red;">Running the Bitnami Support Tool is mandatory when creating a ticket since June 29th. This way we can quickly provide you with a resolution to your question.</p>
     <p class="bnsupport">The Bitnami Support Tool is a command line tool that collects logs and other relevant information and sends it to the Bitnami Support Team. Please run this tool in the affected environment and enter the resulting code in the box below. You can find more information <a href="https://docs.bitnami.com/general/components/bnsupport/" target="_blank">here</a></p>
     <p class="bnsupport">If you run into any issues when running the Bitnami Support Tool, please create a new support request using the "Bitnami Support Tool" option when clicking on "+ New Topic".</p>
     <textarea class="bnsupport" placeholder="12345678-abcd-1234-abcd-123456789abc" maxlength="36" data-link="bnsupportFilled"></textarea>

--- a/public/chokePoint.html
+++ b/public/chokePoint.html
@@ -259,12 +259,12 @@
   <div id="bitnamiContainer" onmouseover="document.documentElement.style.overflow='hidden';" onmouseout="document.documentElement.style.overflow='auto';" class="container padding-bigger padding-v-normal bg-iron elevation-2">
     <div class="row collapse-b-tablet">
       <div class="col-6 margin-h-big margin-t-enormous">
-        <h3>Welcome to the Bitnami Community!!</h3>
+        <h3>Welcome to the Bitnami Community!</h3>
         <p class="margin-t-big">This is a community forum for topics related to the Bitnami Stacks, Virtual Machine or Cloud Images. Please open a new topic for any problems you face related to launching one of our images, accessing it, understanding how to get the login credentials, etc.</p>
         <p>For information regarding applications themselves, we highly recommend checking forums and user guides made available by the projects behind those applications.</p>
         <p>Bitnami’s support team actively participates in this forum Monday to Friday, 10am to 7pm UTC and will try to answer any question they receive within 24 hours.</p>
         <p>In order to promptly find an answer to your question, we will ask you to fill a small form to help us understand how we can best help you.</p>
-        <p>We also recommend you to take a look at the rules of this community, you can find the rules <a href="https://community.bitnami.com/faq" target="_blank">here</a>.</p>
+        <p>We also recommend you to take a look at the rules of this community, that you can find <a href="https://community.bitnami.com/faq" target="_blank">here</a>.</p>
       </div>
       <div class="col-5 margin-h-big margin-t-enormous">
         [^[include tmpl="#type"/]]

--- a/public/chokePoint.html
+++ b/public/chokePoint.html
@@ -93,6 +93,47 @@
   [[/if]]
 </script>
 
+<script id="bndiagnostic-feedback" type="text/x-jsrender">
+  <div>
+    <h4>Bitnami Diagnostic Tool</h4>
+    <p class="bndiagnostic">Could you please let us know why the information was not useful to you?</p>
+    <select tabindex="-1" style="display: block;" data-link="bndiagnosticReasonSelected">
+      <option value="" disabled selected>Select a reason…</option>
+      [[for bndiagnosticReasonsValues]]
+        <option>[[:bndiagnosticReason]]</option>
+      [[/for]]
+    </select>
+    [^[if bndiagnosticReasonSelected]]
+      [^[if bndiagnosticReasonSelected == 'Other']]
+        <textarea required class="bndiagnostic" placeholder="Include useful information for us to improve the diagnostic tool and help users in the future based on your feedback" data-link="bndiagnosticReasonFilled"></textarea>
+      [[/if]]
+    [[/if]]
+  </div>
+</script>
+
+<script id="bndiagnostic-required" type="text/x-jsrender">
+  <div>
+    <h4>Bitnami Diagnostic Tool</h4>
+    <p class="bndiagnostic">Please ensure you review the information that the Bitnami Diagnostic Tool provided you before creating a ticket in this forum.</p>
+  </div>
+</script>
+
+<script id="bndiagnostic" type="text/x-jsrender">
+  <div>
+    <h4>Bitnami Diagnostic Tool</h4>
+    <p class="bndiagnostic">The Bitnami Diagnostic Tool is a self-service command line tool that evaluates your configuration files and logs for errors and provides you with useful information to fix them.</p>
+    <p class="bndiagnostic">Did you review this information?</p>
+    <textarea readonly class="bndiagnostic">[[:getBndiagnostic(bnsupportFilled)]]</textarea>
+  </div>
+</script>
+
+<script id="wait-page" type="text/x-jsrender">
+  <div>
+    <h4>Bitnami Diagnostic Tool</h4>
+    <p class="bnsupport">Please wait until we obtain more info</p>
+  </div>
+</script>
+
 <script id="bnsupport" type="text/x-jsrender">
   <div>
     <h4>Bitnami Support Tool ID <small>recommended</small></h4>
@@ -163,15 +204,88 @@
       [^[include tmpl="#issue"/]]
       <div class="margin-t-small">
         <button class="button" onclick="cancel()">Cancel</button>
-        [^[if typeSelected == 'Technical issue']]
-        <button class="button button-accent" onclick="goToPage4()">Next</button>
-        [[else]]
         <button class="button button-accent" onclick="create()">Create Topic</button>
-        [[/if]]
         <div class="text-r padding-r-giant padding-t-normal" style="float: right">
-          <a onclick="goToPage2()">Go back</a>
+          <a onclick="goToPage5()">Go back</a>
           </div>
       </div>
+    </div>
+  </div>
+</script>
+
+<script id="bndiagnosticFeedback" type="text/x-jsrender">
+  <div class="row collapse-b-tablet">
+    <div class="col-5 margin-h-big">
+      <h3 class="margin-t-small margin-b-normal">Review Bndiagnostic information</h3>
+      [^[include tmpl="#type"/]]
+      [^[include tmpl="#platform"/]]
+      [^[include tmpl="#application"/]]
+      [^[include tmpl="#topic"/]]
+    </div>
+    <div class="col-6 margin-h-big">
+      [^[include tmpl="#bndiagnostic-feedback"/]]
+      <div class="margin-t-small">
+        <button class="button" onclick="cancel()">Cancel</button>
+        <button class="button button-accent" onclick="goToPage6()">Next</button>
+        <div class="text-r padding-r-giant padding-t-normal" style="float: right">
+          <a onclick="goToPage4()">Go back</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</script>
+
+<script id="bndiagnosticRequired" type="text/x-jsrender">
+  <div class="row collapse-b-tablet">
+    <div class="col-5 margin-h-big">
+      <h3 class="margin-t-small margin-b-normal">Review Bndiagnostic information</h3>
+      [^[include tmpl="#type"/]]
+      [^[include tmpl="#platform"/]]
+      [^[include tmpl="#application"/]]
+      [^[include tmpl="#topic"/]]
+    </div>
+    <div class="col-6 margin-h-big">
+      [^[include tmpl="#bndiagnostic-required"/]]
+      <div class="margin-t-small">
+        <button class="button" onclick="cancel()">OK</button>
+      </div>
+    </div>
+  </div>
+</script>
+
+<script id="bndiagnosticPage" type="text/x-jsrender">
+  <div class="row collapse-b-tablet">
+    <div class="col-5 margin-h-big">
+      <h3 class="margin-t-small margin-b-normal">Review Bndiagnostic information</h3>
+      [^[include tmpl="#type"/]]
+      [^[include tmpl="#platform"/]]
+      [^[include tmpl="#application"/]]
+      [^[include tmpl="#topic"/]]
+    </div>
+    <div class="col-6 margin-h-big">
+      [^[include tmpl="#bndiagnostic"/]]
+      <div class="margin-t-small">
+        <button class="button" onclick="goToPage41()">No</button>
+        <button class="button button-accent" onclick="goToPage5()">Yes</button>
+        <div class="text-r padding-r-giant padding-t-normal" style="float: right">
+          <a onclick="goToPage3()">Go back</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</script>
+
+<script id="waitPage" type="text/x-jsrender">
+  <div class="row collapse-b-tablet">
+    <div class="col-5 margin-h-big">
+      <h3 class="margin-t-small margin-b-normal">Add Bnsupport code</h3>
+      [^[include tmpl="#type"/]]
+      [^[include tmpl="#platform"/]]
+      [^[include tmpl="#application"/]]
+      [^[include tmpl="#topic"/]]
+    </div>
+    <div class="col-6 margin-h-big">
+      [^[include tmpl="#wait-page"/]]
     </div>
   </div>
 </script>
@@ -184,17 +298,15 @@
       [^[include tmpl="#platform"/]]
       [^[include tmpl="#application"/]]
       [^[include tmpl="#topic"/]]
-      [^[include tmpl="#title"/]]
-      [^[include tmpl="#issue"/]]
     </div>
     <div class="col-6 margin-h-big">
       [^[include tmpl="#bnsupport"/]]
       <div class="margin-t-small">
         <button class="button" onclick="cancel()">Cancel</button>
-        <button class="button button-accent" onclick="create()">Create topic</button>
+        <button class="button button-accent" onclick="goToPage4()">Next</button>
         <div class="text-r padding-r-giant padding-t-normal" style="float: right">
-          <a onclick="goToPage3()">Go back</a>
-          </div>
+          <a onclick="goToPage2()">Go back</a>
+        </div>
       </div>
     </div>
   </div>

--- a/public/chokePoint.html
+++ b/public/chokePoint.html
@@ -128,8 +128,8 @@
   <div>
     <h4>Bitnami Support Tool ID <small>required</small></h4>
     <p class="bnsupport" style="color:red;">Running the Bitnami Support Tool is mandatory when creating a ticket in this forum from June 29th. This way we can quickly provide you with a resolution to your question.</p>
-    <p class="bnsupport">The Bitnami Support Tool is a command line tool that collects logs and other relevant information and sends it to the Bitnami Support Team. It does not collect any credentials or passwords from your system. Please run this tool in the affected environment and enter the resulting code in the box below. You can find more information <a href="https://docs.bitnami.com/general/components/bnsupport/" target="_blank">here</a></p>
-    <p class="bnsupport">If you run into any issues when running the Bitnami Support tool, please create a new support request using the "Bitnami Support Tool" option when clicking on "+ New Topic".</p>
+    <p class="bnsupport">The Bitnami Support Tool is a command line tool that collects logs and other relevant information and sends it to the Bitnami Support Team. Please run this tool in the affected environment and enter the resulting code in the box below. You can find more information <a href="https://docs.bitnami.com/general/components/bnsupport/" target="_blank">here</a></p>
+    <p class="bnsupport">If you run into any issues when running the Bitnami Support Tool, please create a new support request using the "Bitnami Support Tool" option when clicking on "+ New Topic".</p>
     <textarea class="bnsupport" placeholder="12345678-abcd-1234-abcd-123456789abc" maxlength="36" data-link="bnsupportFilled"></textarea>
   </div>
 </script>

--- a/public/chokePoint.html
+++ b/public/chokePoint.html
@@ -86,13 +86,13 @@
 
 <script id="title" type="text/x-jsrender">
   <h4>Title</h4>
-  <textarea class="title" placeholder="Summarise your [[if typeSelected == 'Technical issue' || typeSelected == 'Bitnami Support Tool']]issue[[else typeSelected == 'How to']]question[[else typeSelected == 'Suggestion']]suggestion[[/if]] in less than 120 characters" maxlength="120" data-link="titleFilled"></textarea>
+  <textarea class="title" placeholder="Summarize your [[if typeSelected == 'Technical issue' || typeSelected == 'Bitnami Support Tool']]issue[[else typeSelected == 'How to']]question[[else typeSelected == 'Suggestion']]suggestion[[/if]] in less than 120 characters" maxlength="120" data-link="titleFilled"></textarea>
 </script>
 
 <script id="bndiagnostic-feedback" type="text/x-jsrender">
   <div>
     <h4>Bitnami Diagnostic Tool Feedback</h4>
-    <p class="bndiagnostic">Please let us know why the information the tool provided was not useful to you</p>
+    <p class="bndiagnostic">Please let us know why the information the tool provided was not useful</p>
     <select tabindex="-1" style="display: block;" data-link="bndiagnosticReasonSelected">
       <option value="" disabled selected>Select a reason…</option>
       [[for bndiagnosticReasonsValues]]
@@ -101,7 +101,7 @@
     </select>
     [^[if bndiagnosticReasonSelected]]
       [^[if bndiagnosticReasonSelected == 'Other']]
-        <textarea required class="bndiagnostic_feedback" placeholder="Include useful information for us to improve the diagnostic tool and help users in the future based on your feedback" data-link="bndiagnosticReasonFilled"></textarea>
+        <textarea required class="bndiagnostic_feedback" placeholder="Include useful information for us to improve the diagnostic tool and help users in the future" data-link="bndiagnosticReasonFilled"></textarea>
       [[/if]]
     [[/if]]
   </div>
@@ -110,7 +110,7 @@
 <script id="bndiagnostic" type="text/x-jsrender">
   <div>
     <h4>Bitnami Diagnostic Tool</h4>
-    <p class="bndiagnostic">The Bitnami Diagnostic Tool is a self-service command line tool that evaluates your configuration files and logs for errors and provides you with useful information to fix them.</p>
+    <p class="bndiagnostic">The Bitnami Diagnostic Tool is a self-service command line tool that evaluates your configuration files and logs looking for errors and provides you with useful information to fix them.</p>
     <p class="bndiagnostic">Did you review this information?</p>
     <div class="bndiagnostic__results">
     </div>

--- a/public/chokePoint.html
+++ b/public/chokePoint.html
@@ -86,17 +86,13 @@
 
 <script id="title" type="text/x-jsrender">
   <h4>Title</h4>
-  [[if currentPage == 4]]
-    <p>[[:titleFilled]]</p>
-    [[else]]
-      <textarea class="title" placeholder="Summarise your question in less than 120 characters" maxlength="120" data-link="titleFilled"></textarea>
-  [[/if]]
+  <textarea class="title" placeholder="Summarise your [[if typeSelected == 'Technical issue' || typeSelected == 'Bitnami Support Tool']]issue[[else typeSelected == 'How to']]question[[else typeSelected == 'Suggestion']]suggestion[[/if]] in less than 120 characters" maxlength="120" data-link="titleFilled"></textarea>
 </script>
 
 <script id="bndiagnostic-feedback" type="text/x-jsrender">
   <div>
-    <h4>Bitnami Diagnostic Tool</h4>
-    <p class="bndiagnostic">Could you please let us know why the information was not useful to you?</p>
+    <h4>Bitnami Diagnostic Tool Feedback</h4>
+    <p class="bndiagnostic">Please let us know why the information the tool provided was not useful to you</p>
     <select tabindex="-1" style="display: block;" data-link="bndiagnosticReasonSelected">
       <option value="" disabled selected>Select a reason…</option>
       [[for bndiagnosticReasonsValues]]
@@ -105,16 +101,9 @@
     </select>
     [^[if bndiagnosticReasonSelected]]
       [^[if bndiagnosticReasonSelected == 'Other']]
-        <textarea required class="bndiagnostic" placeholder="Include useful information for us to improve the diagnostic tool and help users in the future based on your feedback" data-link="bndiagnosticReasonFilled"></textarea>
+        <textarea required class="bndiagnostic_feedback" placeholder="Include useful information for us to improve the diagnostic tool and help users in the future based on your feedback" data-link="bndiagnosticReasonFilled"></textarea>
       [[/if]]
     [[/if]]
-  </div>
-</script>
-
-<script id="bndiagnostic-required" type="text/x-jsrender">
-  <div>
-    <h4>Bitnami Diagnostic Tool</h4>
-    <p class="bndiagnostic">Please ensure you review the information that the Bitnami Diagnostic Tool provided you before creating a ticket in this forum.</p>
   </div>
 </script>
 
@@ -123,7 +112,9 @@
     <h4>Bitnami Diagnostic Tool</h4>
     <p class="bndiagnostic">The Bitnami Diagnostic Tool is a self-service command line tool that evaluates your configuration files and logs for errors and provides you with useful information to fix them.</p>
     <p class="bndiagnostic">Did you review this information?</p>
-    <textarea readonly class="bndiagnostic">[[:getBndiagnostic(bnsupportFilled)]]</textarea>
+    <div class="bndiagnostic__results">
+      <pre class="bndiagnostic__text">Loading results...</pre>
+    </div>
   </div>
 </script>
 
@@ -136,22 +127,18 @@
 
 <script id="bnsupport" type="text/x-jsrender">
   <div>
-    <h4>Bitnami Support Tool ID <small>recommended</small></h4>
+    <h4>Bitnami Support Tool ID <small>required</small></h4>
     <p class="bnsupport">The Bitnami Support Tool is a command line tool that collects logs and other relevant information and sends it to the Bitnami Support Team. It does not collect any credentials or passwords from your system. </p>
     <br/>
     <p class="bnsupport">To ensure we can quickly provide you with a resolution to your question, please run this tool in the affected environment. After running the tool, enter the resulting code in the box below. You can find more information <a href="https://docs.bitnami.com/general/components/bnsupport/" target="_blank">here</a>.</p>
-    <textarea class="bnsupport" placeholder="123456789-abcd-1234-abcd-123456789abc" maxlength="37" data-link="bnsupportFilled"></textarea>
+    <textarea class="bnsupport" placeholder="12345678-abcd-1234-abcd-123456789abc" maxlength="36" data-link="bnsupportFilled"></textarea>
   </div>
 </script>
 
 <script id="issue" type="text/x-jsrender">
   <div>
-    <h4>[[if typeSelected == 'Technical issue']]Description[[else typeSelected == 'How to']]Describe your question here[[else typeSelected == 'Suggestion']]Describe your suggestion here[[/if]]</h4>
-    [[if currentPage == 4]]
-      <p>[[:textareaSanitized]]</p>
-      [[else]]
-        <textarea class="issue" placeholder="Include [[if typeSelected == 'Technical issue']]detailed steps to reproduce the issue[[else typeSelected == 'Suggestion']]your suggestion as detailed as possible[[else]]your question as detailed as possible[[/if]]" data-link="textareaFilled" required></textarea>
-    [[/if]]
+    <h4>[[if typeSelected == 'Technical issue']]Description[[else typeSelected == 'How to']]Describe your question here[[else typeSelected == 'Bitnami Support Tool']]Describe the issues with the Bitnami Support Tool here[[else typeSelected == 'Suggestion']]Describe your suggestion here[[/if]]</h4>
+    <textarea class="issue" placeholder="Include [[if typeSelected == 'Technical issue']]detailed steps to reproduce the issue[[else typeSelected == 'Bitnami Support Tool']]detailed information about the error you are getting[[else typeSelected == 'Suggestion']]your suggestion as detailed as possible[[else]]your question as detailed as possible[[/if]]" data-link="textareaFilled" required></textarea>
   </div>
   <div class="text-r padding-r-giant">
     <a href="https://guides.github.com/features/mastering-markdown/" target="_blank">Styling with Markdown is supported</a>
@@ -182,7 +169,11 @@
   </div>
   <div>
     <h4 class="margin-t-small">Have you found what you were looking for?</h4>
-    <button class="button button-action" onclick="goToPage3()">No</button>
+    [^[if typeSelected == 'Technical issue']]
+      <button class="button button-action" onclick="goToPage3()">No</button>
+    [[else]]
+      <button class="button button-action" onclick="goToPage5()">No</button>
+    [[/if]]
     <button class="button button-accent" onclick="cancel()">Yes</button>
     <div class="text-r padding-r-normal padding-t-normal" style="float: right">
       <a onclick="goToPage1()">Go back</a>
@@ -202,52 +193,19 @@
     <div class="col-6 margin-h-big">
       [^[include tmpl="#title"/]]
       [^[include tmpl="#issue"/]]
+      [^[if typeSelected == 'Technical issue' && !(platformSelected == 'Windows' || platformSelected == 'OS X' || platformSelected == 'Linux')]]
+        [^[include tmpl="#bndiagnostic-feedback"/]]
+      [[/if]]
       <div class="margin-t-small">
         <button class="button" onclick="cancel()">Cancel</button>
         <button class="button button-accent" onclick="create()">Create Topic</button>
         <div class="text-r padding-r-giant padding-t-normal" style="float: right">
-          <a onclick="goToPage5()">Go back</a>
+          [^[if typeSelected != 'Technical issue']]
+            <a onclick="goToPage2()">Go back</a>
+          [[else]]
+            <a onclick="goToPage3()">Go back</a>
+          [[/if]]
           </div>
-      </div>
-    </div>
-  </div>
-</script>
-
-<script id="bndiagnosticFeedback" type="text/x-jsrender">
-  <div class="row collapse-b-tablet">
-    <div class="col-5 margin-h-big">
-      <h3 class="margin-t-small margin-b-normal">Review Bndiagnostic information</h3>
-      [^[include tmpl="#type"/]]
-      [^[include tmpl="#platform"/]]
-      [^[include tmpl="#application"/]]
-      [^[include tmpl="#topic"/]]
-    </div>
-    <div class="col-6 margin-h-big">
-      [^[include tmpl="#bndiagnostic-feedback"/]]
-      <div class="margin-t-small">
-        <button class="button" onclick="cancel()">Cancel</button>
-        <button class="button button-accent" onclick="goToPage6()">Next</button>
-        <div class="text-r padding-r-giant padding-t-normal" style="float: right">
-          <a onclick="goToPage4()">Go back</a>
-        </div>
-      </div>
-    </div>
-  </div>
-</script>
-
-<script id="bndiagnosticRequired" type="text/x-jsrender">
-  <div class="row collapse-b-tablet">
-    <div class="col-5 margin-h-big">
-      <h3 class="margin-t-small margin-b-normal">Review Bndiagnostic information</h3>
-      [^[include tmpl="#type"/]]
-      [^[include tmpl="#platform"/]]
-      [^[include tmpl="#application"/]]
-      [^[include tmpl="#topic"/]]
-    </div>
-    <div class="col-6 margin-h-big">
-      [^[include tmpl="#bndiagnostic-required"/]]
-      <div class="margin-t-small">
-        <button class="button" onclick="cancel()">OK</button>
       </div>
     </div>
   </div>
@@ -265,27 +223,12 @@
     <div class="col-6 margin-h-big">
       [^[include tmpl="#bndiagnostic"/]]
       <div class="margin-t-small">
-        <button class="button" onclick="goToPage41()">No</button>
-        <button class="button button-accent" onclick="goToPage5()">Yes</button>
+      <button class="button" onclick="cancel()">Cancel</button>
+        <button class="button button-accent" onclick="goToPage5()" disabled="true">Next</button>
         <div class="text-r padding-r-giant padding-t-normal" style="float: right">
           <a onclick="goToPage3()">Go back</a>
         </div>
       </div>
-    </div>
-  </div>
-</script>
-
-<script id="waitPage" type="text/x-jsrender">
-  <div class="row collapse-b-tablet">
-    <div class="col-5 margin-h-big">
-      <h3 class="margin-t-small margin-b-normal">Add Bnsupport code</h3>
-      [^[include tmpl="#type"/]]
-      [^[include tmpl="#platform"/]]
-      [^[include tmpl="#application"/]]
-      [^[include tmpl="#topic"/]]
-    </div>
-    <div class="col-6 margin-h-big">
-      [^[include tmpl="#wait-page"/]]
     </div>
   </div>
 </script>
@@ -303,7 +246,7 @@
       [^[include tmpl="#bnsupport"/]]
       <div class="margin-t-small">
         <button class="button" onclick="cancel()">Cancel</button>
-        <button class="button button-accent" onclick="goToPage4()">Next</button>
+        <button class="button button-accent" onclick="validateBnsupport()">Next</button>
         <div class="text-r padding-r-giant padding-t-normal" style="float: right">
           <a onclick="goToPage2()">Go back</a>
         </div>
@@ -328,7 +271,7 @@
         [^[if typeSelected]]
           [^[if typeSelected == 'How to' || typeSelected == 'Technical issue']]
             [^[include tmpl="#platform"/]]
-            [^[if platformSelected && platformSelected != 'Containers']]
+            [^[if platformSelected && !(platformSelected == 'Containers' || platformSelected == 'Charts')]]
               [^[include tmpl="#application"/]]
               [^[if applicationSelected]]
                 [[for applicationValues]]
@@ -343,24 +286,28 @@
             [[/if]]
           [[else typeSelected == 'Sales & Account']]
             <p>For sales and account questions, we will help you in our HelpDesk service.</p>
-          [[else typeSelected == 'Suggestion']]
+          [[else typeSelected == 'Suggestion' || typeSelected == 'Bitnami Support Tool']]
             [^[include tmpl="#title"/]]
             [^[include tmpl="#issue"/]]
           [[/if]]
         [[/if]]
-        [^[if ((typeSelected == 'How to' || typeSelected == 'Technical issue') && (platformSelected && platformSelected != 'Containers') && applicationSelected && topicSelected)]]
+        [^[if ((typeSelected == 'How to' || typeSelected == 'Technical issue') && (platformSelected && !(platformSelected == 'Containers' || platformSelected == 'Charts')) && applicationSelected && topicSelected)]]
           <button class="button" onclick="cancel()">Cancel</button>
           <button class="button button-accent" onclick="goToPage2()">Next</button>
         [^[else typeSelected == 'Sales & Account']]
           <button class="button" onclick="cancel()">Cancel</button>
           <button class="button button-accent" onclick="goToHelpdesk()">Go to Bitnami HelpDesk</button>
-        [^[else typeSelected == 'Suggestion']]
+        [^[else typeSelected == 'Suggestion' || typeSelected == 'Bitnami Support Tool']]
           <button class="button" onclick="cancel()">Cancel</button>
           <button class="button button-accent" onclick="create()">Create topic</button>
         [^[else platformSelected == 'Containers']]
-          <p>The Bitnami Community for container issues is located on GitHub. You can create a GitHub issue on the Issues section of the container.</p>
+          <p>The Bitnami Community for container issues is located on GitHub. You can create a GitHub issue on the Issues section of the Bitnami container's repository.</p>
           <button class="button" onclick="cancel()">Cancel</button>
           <button class="button button-accent" onclick="window.open('https://github.com/bitnami/','_blank')">Go to Bitnami GitHub</button>
+        [^[else platformSelected == 'Charts']]
+          <p>The Bitnami Community for chart issues is located on GitHub. You can create a GitHub issue on the Issues section of the Bitnami Chart's repository.</p>
+          <button class="button" onclick="cancel()">Cancel</button>
+          <button class="button button-accent" onclick="window.open('https://github.com/bitnami/charts/issues','_blank')">Go to Bitnami Charts GitHub</button>
         [[else]]
             <button class="button" onclick="cancel()">Cancel</button>
         [[/if]]


### PR DESCRIPTION
This PR includes the following changes:

- The bnsupport info is not mandatory and needs to be recent
- The chokepoint now uses a AWS API to get the bndiagnostic information
- Updated list of supported platforms 
- Updated list of typeArray values