### PR TITLE
Update chokepoint with the new URL to get the bndiagnostic information

### DIFF
--- a/assets/javascripts/discourse/initializers/chokePoint.js.es6
+++ b/assets/javascripts/discourse/initializers/chokePoint.js.es6
@@ -10,7 +10,7 @@ export default {
     const communityURL = window.location.origin;
     let endpointURL;
     if (/community.bitnami.com/.test(window.location.host)) {
-      endpointURL="https://bndiagnostic-retrieval.web.bitnami.net"
+      endpointURL="https://bndiagnostic-retrieval.bitnami.com"
     } else {
       endpointURL="https://bndiagnostic-retrieval.dev.bitnami.net"
     }
@@ -240,9 +240,7 @@ If you continue running into issues when running the Bitnami Support tool, pleas
         window.validateBnsupport = function validateBnsupport() {
           const bnsupportIDRegex = new RegExp(/[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}/);
           if (bnsupportIDRegex.test(allData.bnsupportFilled)) {
-            if (allData.platformSelected == 'Windows' ||
-              allData.platformSelected == 'OS X' ||
-              allData.platformSelected == 'Linux') {
+            if (allData.platformSelected == 'Installers') {
               goToPage5();
             } else {
               goToPage4();

--- a/public/chokePoint.html
+++ b/public/chokePoint.html
@@ -192,7 +192,7 @@
     <div class="col-6 margin-h-big">
       [^[include tmpl="#title"/]]
       [^[include tmpl="#issue"/]]
-      [^[if typeSelected == 'Technical issue' && !(platformSelected == 'Windows' || platformSelected == 'OS X' || platformSelected == 'Linux')]]
+      [^[if typeSelected == 'Technical issue' && platformSelected != 'Installers']]
         [^[include tmpl="#bndiagnostic-feedback"/]]
       [[/if]]
       <div class="margin-t-small">


### PR DESCRIPTION
This PR updates the URL of the bndiagnostic-retrieval AWS LB and removes the "Windows", "Linux" and "OS X" references